### PR TITLE
Added QCDregions and subcatogories

### DIFF
--- a/Analysis/H_mumu.py
+++ b/Analysis/H_mumu.py
@@ -18,7 +18,7 @@ defaultColToSave = ["FullEventId","luminosityBlock", "run","event", "sample_type
 def createKeyFilterDict(global_cfg_dict, year):
     filter_dict = {}
     filter_str = ""
-    channels_to_consider = global_cfg_dict['channelSelection']
+    channels_to_consider = global_cfg_dict['channels_to_consider']
     sign_regions_to_consider = global_cfg_dict['QCDRegions']
     categories_to_consider = global_cfg_dict["categories"]
     triggers_dict = global_cfg_dict['hist_triggers']

--- a/Analysis/H_mumu.py
+++ b/Analysis/H_mumu.py
@@ -14,11 +14,11 @@ JetObservablesMC = ["hadronFlavour","partonFlavour", "genJetIdx"]
 defaultColToSave = ["FullEventId","luminosityBlock", "run","event", "sample_type", "period", "isData","PuppiMET_pt", "PuppiMET_phi", "nJet","DeepMETResolutionTune_pt", "DeepMETResolutionTune_phi","DeepMETResponseTune_pt", "DeepMETResponseTune_phi","PV_npvs"]
 
 
-# The previous version of this loop before making QCDregions as a dict in global and it remains same
+
 def createKeyFilterDict(global_cfg_dict, year):
     filter_dict = {}
     filter_str = ""
-    channels_to_consider = global_cfg_dict['channels_to_consider']
+    channels_to_consider = global_cfg_dict['channelSelection']
     sign_regions_to_consider = global_cfg_dict['QCDregions']
     categories_to_consider = global_cfg_dict["categories"]
     triggers_dict = global_cfg_dict['hist_triggers']
@@ -202,15 +202,12 @@ class DataFrameBuilderForHistograms(DataFrameBuilderBase):
                     print(f"{trg_name} not present in colNames")
                     self.df = self.df.Define(trg_name, "1")
 
-    # def defineRegions(self):
-    #      self.df = self.df.Define("Z_sideband", "m_mumu > 70 && m_mumu < 110")
-    def defineRegions(self, global_cfg_dict):
-    # new: QCDRegions is a dict {region_name: cut_string}
-    region_defs = global_cfg_dict['QCDRegions']
-    for reg_name, reg_cut in region_defs.items():
-        # reg_name → branch name, reg_cut → actual selection
-        self.df = self.df.Define(reg_name, reg_cut)
-    return self.df
+   
+    def defineRegions(self):
+        region_defs = global_cfg_dict['QCDregions']
+        for reg_name, reg_cut in region_defs.items():
+            self.df = self.df.Define(reg_name, reg_cut)
+        return self.df
 
 
     def SignRegionDef(self):

--- a/Analysis/H_mumu.py
+++ b/Analysis/H_mumu.py
@@ -19,7 +19,7 @@ def createKeyFilterDict(global_cfg_dict, year):
     filter_dict = {}
     filter_str = ""
     channels_to_consider = global_cfg_dict['channelSelection']
-    sign_regions_to_consider = global_cfg_dict['QCDregions']
+    sign_regions_to_consider = global_cfg_dict['QCDRegions']
     categories_to_consider = global_cfg_dict["categories"]
     triggers_dict = global_cfg_dict['hist_triggers']
     for ch in channels_to_consider:
@@ -204,10 +204,10 @@ class DataFrameBuilderForHistograms(DataFrameBuilderBase):
 
    
     def defineRegions(self):
-        region_defs = global_cfg_dict['QCDregions']
+        region_defs = self.config['QCDRegions']
         for reg_name, reg_cut in region_defs.items():
             self.df = self.df.Define(reg_name, reg_cut)
-        # return self.df
+        
 
 
     def SignRegionDef(self):

--- a/Analysis/H_mumu.py
+++ b/Analysis/H_mumu.py
@@ -207,7 +207,7 @@ class DataFrameBuilderForHistograms(DataFrameBuilderBase):
         region_defs = global_cfg_dict['QCDregions']
         for reg_name, reg_cut in region_defs.items():
             self.df = self.df.Define(reg_name, reg_cut)
-        return self.df
+        # return self.df
 
 
     def SignRegionDef(self):
@@ -229,7 +229,7 @@ class DataFrameBuilderForHistograms(DataFrameBuilderBase):
     def defineChannels(self):
         self.df = self.df.Define(f"muMu", f"return true;")
 
-    def __init__(self, df, config, period,isData=False, isCentral=False, colToSave=[]):
+    def __init__(self, df, config, period, isData=False, isCentral=False, colToSave=[]):
         super(DataFrameBuilderForHistograms, self).__init__(df)
         self.config = config
         self.isData = isData

--- a/Analysis/H_mumu.py
+++ b/Analysis/H_mumu.py
@@ -14,26 +14,51 @@ JetObservablesMC = ["hadronFlavour","partonFlavour", "genJetIdx"]
 defaultColToSave = ["FullEventId","luminosityBlock", "run","event", "sample_type", "period", "isData","PuppiMET_pt", "PuppiMET_phi", "nJet","DeepMETResolutionTune_pt", "DeepMETResolutionTune_phi","DeepMETResponseTune_pt", "DeepMETResponseTune_phi","PV_npvs"]
 
 
+# The previous version of this loop before making QCDregions as a dict in global
+# def createKeyFilterDict(global_cfg_dict, year):
+#     filter_dict = {}
+#     filter_str = ""
+#     channels_to_consider = global_cfg_dict['channels_to_consider']
+#     sign_regions_to_consider = global_cfg_dict['QCDregions']
+#     categories_to_consider = global_cfg_dict["categories"]
+#     triggers_dict = global_cfg_dict['hist_triggers']
+#     for ch in channels_to_consider:
+#         triggers = triggers_dict[ch]['default']
+#         if year in triggers_dict[ch].keys():
+#             triggers = triggers_dict[ch][year]
+#         for reg in sign_regions_to_consider:
+#             for cat in categories_to_consider:
+#                 filter_base = f" ({ch} && {triggers}&& {reg} && {cat})"
+#                 filter_str = f"(" + filter_base
+#                 filter_str += ")"
+#                 key = (ch, reg, cat)
+#                 filter_dict[key] = filter_str
+#     return filter_dict
 
+# new loop after making QCDregions a dict in global
 def createKeyFilterDict(global_cfg_dict, year):
     filter_dict = {}
     filter_str = ""
-    channels_to_consider = global_cfg_dict['channels_to_consider']
-    sign_regions_to_consider = global_cfg_dict['QCDRegions']
+    channels_to_consider   = global_cfg_dict['channels_to_consider']
+    # now a dict of region_name → cut_string
+    region_defs            = global_cfg_dict['QCDRegions']
     categories_to_consider = global_cfg_dict["categories"]
-    triggers_dict = global_cfg_dict['hist_triggers']
+    triggers_dict          = global_cfg_dict['hist_triggers']
+
     for ch in channels_to_consider:
         triggers = triggers_dict[ch]['default']
-        if year in triggers_dict[ch].keys():
+        if year in triggers_dict[ch]:
             triggers = triggers_dict[ch][year]
-        for reg in sign_regions_to_consider:
+        for reg_name, reg_cut in region_defs.items():
             for cat in categories_to_consider:
-                filter_base = f" ({ch} && {triggers}&& {reg} && {cat})"
-                filter_str = f"(" + filter_base
-                filter_str += ")"
-                key = (ch, reg, cat)
-                filter_dict[key] = filter_str
+                filter_base        = f" ({ch} && {triggers} && {reg_cut} && {cat})"
+                filter_str         = f"({filter_base})"
+                key                = (ch, reg_name, cat)
+                filter_dict[key]   = filter_str
+
     return filter_dict
+
+
 
 def GetBTagWeight(global_cfg_dict,cat,applyBtag=False):
     btag_weight = "1"

--- a/Analysis/make_stackplot.py
+++ b/Analysis/make_stackplot.py
@@ -1,45 +1,80 @@
 import os
-if __name__ == '__main__':
-    import argparse
-    parser = argparse.ArgumentParser(description='Create TrainTest Files for DNN.')
-    parser.add_argument('--var', required=True, type=str, help="vars, separated by commas")
-    parser.add_argument('--era', required= False, type=str, default="Run3_2022EE", help="era")
-    parser.add_argument('--histDir', required= False, type=str, default="/eos/user/v/vdamante/H_mumu/histograms/", help="era")
-    parser.add_argument('--version', required= False, type=str, default="Run3_2022EE_Hmumu_v2", help="version for input files")
-    parser.add_argument('--categories', required= False, type=str, help="categories")
-    parser.add_argument('--wantNonLog', required= False, type=bool, default=False,help="use uncertainties")
-    parser.add_argument('--wantLog', required= False, type=bool, default=False,help="use uncertainties")
-    parser.add_argument('--use_unc', required= False, type=bool, default=False,help="use uncertainties")
-    args = parser.parse_args()
 
-    era = args.era #"Run3_2022EE"
-    ver = args.version # "Run3_2022EE_Hmumu_v2"
+era = "Run3_2022EE"
+ver = "Run3_2022EE_Hmumu_v2"
+common_path = f"/afs/cern.ch/user/s/sabhosal/H_mumu" # CHANGE TO YOURS
+using_uncertainties = False #True #When we turn on Up/Down, the file storage changes due to renameHists.py
+# varnames = [ "mu1_eta" , "mu2_eta" ]
+# varnames = ["m_mumu","pt_ll","mu1_pt","mu2_pt" ,"dR_mumu" ,  "mu1_eta" , "mu1_phi" ,  "mu2_eta" , "mu2_phi"  ]
+# varnames = ["VBF_etaSeparation","VBFjet1_eta","VBFjet2_eta","mu1_pt","mu2_pt","VBFjet1_pt","VBFjet2_pt","m_mumu", "VBF_mInv"]
+# varnames = ["m_mumu", "pt_ll", "VBF_etaSeparation", "VBFjet1_eta"]
+# varnames = ["pt_mumu"]
+# varnames = ["m_mumu", "mu1_pt", "mu2_pt", "pt_mumu"] # "m_jj",
+varnames = ["pt_mumu"]
 
-    common_path = os.getcwd() # f"/afs/cern.ch/work/v/vdamante/H_mumu"
-    using_uncertainties = args.use_unc #True #When we turn on Up/Down, the file storage changes due to renameHists.py
+channellist = ["muMu"]
 
-    varnames = args.var.split(",")
-    categories = ["baseline", "VBF", "ggH", "baseline_Zmumu", "VBF_Zmumu", "ggH_Zmumu", "VBF_JetVeto", "VBF_Zmumu_JetVeto"]
-    if args.categories:
-        categories = args.categories.split(",")
+categories = ["baseline", "VBF", "ggH", "VBF_JetVeto"]
 
-    indir = os.path.join(args.histDir, ver, era, "merged")
-    plotdir = os.path.join(args.histDir, ver, era, "plots")
+# Including QCD control regions
+qcd_regions = ["Z_sideband", "H_sideband"]
 
-    for var in varnames:
+indir = f"/eos/user/s/sabhosal/H_mumu/histograms/Run3_2022EE_Hmumu_v2/Run3_2022EE/merged" # CHANGE TO YOURS
+plotdir = f"/eos/user/s/sabhosal/H_mumu/histograms/Run3_2022EE_Hmumu_v2/Run3_2022EE/plots" # CHANGE TO YOURS
+
+for var in varnames:
+    for channel in channellist:
         for cat in categories:
-            filename = os.path.join(indir, var, f"{var}.root")
-            os.makedirs(os.path.join(plotdir,cat), exist_ok=True)
 
-            if not using_uncertainties:
-                if args.wantLog:
-                    outname = os.path.join(plotdir,cat, f"{var}_yLog.pdf")
-                    os.system(f"python3 {common_path}/FLAF/Analysis/HistPlotter.py --inFile {filename} --bckgConfig {common_path}/config/background_samples.yaml --globalConfig {common_path}/config/global.yaml --outFile {outname} --var {var} --category {cat} --channel muMu --uncSource Central --wantData --year {era} --wantQCD False --wantLogScale y --rebin False --analysis H_mumu --qcdregion OS --sigConfig {common_path}/config/signal_samples.yaml --wantSignals")
+            # Looping over every QCD control region and making a plot for eachof them
+            for qcd_region in qcd_regions:
 
-                if args.wantNonLog:
-                    outname = os.path.join(plotdir,cat, f"{var}.pdf")
-                    os.system(f"python3 {common_path}/FLAF/Analysis/HistPlotter.py --inFile {filename} --bckgConfig {common_path}/config/background_samples.yaml --globalConfig {common_path}/config/global.yaml --outFile {outname} --var {var} --category {cat} --channel muMu --uncSource Central --wantData --year {era} --wantQCD False --rebin False --analysis H_mumu --qcdregion OS --sigConfig {common_path}/config/{era}/samples.yaml")
+                filename = os.path.join(indir, var, f"{var}.root")
+                # print("Loading fname ", filename)
+                os.makedirs(os.path.join(plotdir, cat), exist_ok=True)
+                outname = os.path.join(plotdir, cat, f"{var}_{qcd_region}_yLog.pdf")
 
-            else:
-                filename = os.path.join(indir, var, 'tmp', f"all_histograms_{var}_hadded.root")
-                os.system(f"python3 /afs/cern.ch/work/v/vdamante/H_mumu/FLAF/Analysis/HistPlotter.py --inFile {filename} --bckgConfig ../config/background_samples.yaml --globalConfig ../config/global.yaml --outFile {outname} --var {var} --category {cat} --channel muMu --uncSource Central --wantData --year {era} --wantQCD False --rebin False --analysis H_mumu --qcdregion OS_Iso --sigConfig ../config/{era}/samples.yaml")
+                if not using_uncertainties:
+                    os.system(
+                        f"python3 {common_path}/FLAF/Analysis/HistPlotter.py "
+                        f"--inFile {filename} "
+                        f"--bckgConfig {common_path}/config/background_samples.yaml "
+                        f"--globalConfig {common_path}/config/global.yaml "
+                        f"--outFile {outname} "
+                        f"--var {var} "
+                        f"--category {cat} "
+                        f"--channel {channel} "
+                        f"--uncSource Central "
+                        f"--wantData "
+                        f"--year {era} "
+                        f"--wantQCD False "
+                        f"--wantLogScale y "
+                        f"--rebin False "
+                        f"--analysis H_mumu "
+                        f"--qcdregion {qcd_region} "  # <- QCDRegion name passed here
+                        f"--sigConfig {common_path}/config/signal_samples.yaml "
+                        f"--wantSignals"
+                    )
+
+                    # outname = os.path.join(plotdir, f"H_mumu_{var}_StackPlot.pdf")
+                    # os.system(f"python3 {common_path}/FLAF/Analysis/HistPlotter.py --inFile {filename} --bckgConfig {common_path}/config/background_samples.yaml --globalConfig {common_path}/config/global.yaml --outFile {outname} --var {var} --category {cat} --channel {channel} --uncSource Central --wantData --year {era} --wantQCD False --rebin False --analysis H_mumu --qcdregion OS --sigConfig {common_path}/config/{era}/samples.yaml")
+                else:
+                    filename_tmp = os.path.join(indir, var, "tmp", f"all_histograms_{var}_hadded.root")
+                    os.system(
+                        f"python3 /afs/cern.ch/work/v/vdamante/H_mumu/FLAF/Analysis/HistPlotter.py "
+                        f"--inFile {filename_tmp} "
+                        f"--bckgConfig ../config/background_samples.yaml "
+                        f"--globalConfig ../config/global.yaml "
+                        f"--outFile {outname} "
+                        f"--var {var} "
+                        f"--category {cat} "
+                        f"--channel {channel} "
+                        f"--uncSource Central "
+                        f"--wantData "
+                        f"--year {era} "
+                        f"--wantQCD False "
+                        f"--rebin False "
+                        f"--analysis H_mumu "
+                        f"--qcdregion {qcd_region} "
+                        f"--sigConfig ../config/{era}/samples.yaml"
+                    )

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -34,7 +34,7 @@ corrections:
 region: All
 region_default: All
 
-QCDregions:
+QCDRegions:
   Z_sideband: "m_mumu > 70 && m_mumu < 110"
   Signal_Fit: "m_mumu > 115 && m_mumu < 135"
   H_sideband: "((m_mumu > 110 && m_mumu < 115) || (m_mumu > 135 && m_mumu < 150))"
@@ -52,7 +52,7 @@ categories:
   - VBF
   - ggH
   - VBF_JetVeto
-  - ggH_JetVeto
+  # - ggH_JetVeto
 
 category_definition:
   baseline: "OS && (mu1_pt > {MuPtTh} && mu2_pt > {MuPtTh})"
@@ -61,7 +61,7 @@ category_definition:
   ggH: "baseline && !(VBF_def)"
   VBF_JetVeto_def: "VBF_def && ((abs(j1_eta) < 2.5 || abs(j1_eta) > 3 || j1_pt > 50) && (abs(j2_eta) < 2.5 || abs(j2_eta) > 3 || j2_pt > 50))"
   VBF_JetVeto: "baseline && VBF_JetVeto_def"
-  ggH_JetVeto: "baseline && !VBF_JetVeto_def"
+  # ggH_JetVeto: "baseline && !VBF_JetVeto_def"
 
 singleMu_th:
   "Run2_2016": 26

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -22,7 +22,6 @@ channelDefinition:
   eMu: 12
   muMu: 22
 
-
 corrections:
   # - JEC
   - JER
@@ -35,11 +34,12 @@ corrections:
 region: All
 region_default: All
 
+# keeping the same naming covention as Stephens prev analysis
 QCDRegions:
   - Z_sideband
-  # - Signal_Fit
-  # - Signal_ext
-  # - H_sideband
+  - Signal_Fit
+  - Signal_ext
+  - H_sideband
 
 ApplyBweight: False
 triggers:
@@ -52,44 +52,60 @@ categories:
   - baseline
   - VBF
   - ggH
-
-
+  - VBF_JetVeto
+  - ggH_JetVeto
 
 category_definition:
-  baseline: "OS && (mu1_pt > {MuPtTh} && mu2_pt > {MuPtTh})" # OS = opposite charge sign for two muons
-  VBF_def : "HasVBF && j1_pt > 25 && j2_pt >25"
-  VBF: "baseline && VBF_def"
-  ggH: "baseline && !(VBF_def)"
-  # https://gitlab.cern.ch/cms-jetmet/coordination/coordination/-/issues/113 --> data/MC differences in Jet distributions
-  # spikes are pT dependent, increasing the pT threshold to 50 GeV let them disappear, but reduces significantly the analysis sensitivity
-  # non-physics dependent, but related to Jet Energy Correction and Scale
-  VBF_JetVeto_def: "VBF_def && ( (abs(j1_eta) < 2.5 || abs(j1_eta) > 3 || j1_pt > 50) ) && ( (abs(j2_eta) < 2.5 || abs(j2_eta) > 3 || j2_pt > 50) )"
-  VBF_JetVeto: "baseline && VBF_def && ( (abs(j1_eta) < 2.5 || abs(j1_eta) > 3 || j1_pt > 50) ) && ( (abs(j2_eta) < 2.5 || abs(j2_eta) > 3 || j2_pt > 50) )"
-  ggH_VBFJetVeto: " baseline && !(VBF_JetVeto_def) " # no needed
+  # main categories
+  baseline:      "OS && (mu1_pt > {MuPtTh} && mu2_pt > {MuPtTh})"
+  VBF_def:       "HasVBF && j1_pt > 25 && j2_pt >25"
+  VBF:           "baseline && VBF_def"
+  ggH:           "baseline && !(VBF_def)"
 
-  # # Control region peaking around Z mass
-  # baseline_Zmumu: "baseline && DYEnriched"
-  # VBF_Zmumu: "baseline_Zmumu && VBF_def "
-  # ggH_Zmumu: "baseline_Zmumu && !(VBF_def) "
+  # temporary jet‐veto subcategoriesa
+  VBF_JetVeto_def: >
+    VBF_def
+    && (
+         (abs(j1_eta) < 2.5 || abs(j1_eta) > 3 || j1_pt > 50)
+      && (abs(j2_eta) < 2.5 || abs(j2_eta) > 3 || j2_pt > 50)
+       )
+  VBF_JetVeto:   "baseline && VBF_JetVeto_def"
+  ggH_JetVeto:   "baseline && !VBF_JetVeto_def"
 
-  # # Control region peaking around Z mass + VBF Jets veto application
-  # VBF_Zmumu_JetVeto: "baseline_Zmumu && VBF_JetVeto_def"
-  # ggH_Zmumu_JetVeto: "baseline_Zmumu && !VBF_JetVeto_def" # no needed
+  # QCDs control and signal regions by dimuon mass 
+  Z_sideband:   >
+    baseline
+    && mumu_mass > 70
+    && mumu_mass < 110
 
+  Signal_Fit:   >
+    baseline
+    && mumu_mass > 115
+    && mumu_mass < 135
+
+  H_sideband:   >
+    baseline
+    && (
+         (mumu_mass > 110 && mumu_mass < 115)
+      || (mumu_mass > 135 && mumu_mass < 150)
+       )
+
+  Signal_ext:   >
+    baseline
+    && mumu_mass > 110
+    && mumu_mass < 150
 
 singleMu_th:
-  "Run2_2016": 26
+  "Run2_2016":      26
   "Run2_2016_HIPM": 26
-  "Run2_2017": 29
-  "Run2_2018": 26
-  "Run3_2022": 26
-  "Run3_2022EE": 26
-
+  "Run2_2017":      29
+  "Run2_2018":      26
+  "Run3_2022":      26
+  "Run3_2022EE":    26
 
 scales:
   - Up
   - Down
-
 
 sample_types_to_merge:
   - DY

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -34,12 +34,12 @@ corrections:
 region: All
 region_default: All
 
-# keeping the same naming covention as Stephens prev analysis
+# QCD control regions by dimuon mass
 QCDRegions:
-  - Z_sideband
-  - Signal_Fit
-  - Signal_ext
-  - H_sideband
+  Z_sideband: "baseline && mumu_mass > 70 && mumu_mass < 110"
+  Signal_Fit: "baseline && mumu_mass > 115 && mumu_mass < 135"
+  H_sideband: "baseline && ((mumu_mass > 110 && mumu_mass < 115) || (mumu_mass > 135 && mumu_mass < 150))"
+  Signal_ext: "baseline && mumu_mass > 110 && mumu_mass < 150"
 
 ApplyBweight: False
 triggers:
@@ -57,51 +57,22 @@ categories:
 
 category_definition:
   # main categories
-  baseline:      "OS && (mu1_pt > {MuPtTh} && mu2_pt > {MuPtTh})"
-  VBF_def:       "HasVBF && j1_pt > 25 && j2_pt >25"
-  VBF:           "baseline && VBF_def"
-  ggH:           "baseline && !(VBF_def)"
-
-  # temporary jet‐veto subcategoriesa
-  VBF_JetVeto_def: >
-    VBF_def
-    && (
-         (abs(j1_eta) < 2.5 || abs(j1_eta) > 3 || j1_pt > 50)
-      && (abs(j2_eta) < 2.5 || abs(j2_eta) > 3 || j2_pt > 50)
-       )
-  VBF_JetVeto:   "baseline && VBF_JetVeto_def"
-  ggH_JetVeto:   "baseline && !VBF_JetVeto_def"
-
-  # QCDs control and signal regions by dimuon mass 
-  Z_sideband:   >
-    baseline
-    && mumu_mass > 70
-    && mumu_mass < 110
-
-  Signal_Fit:   >
-    baseline
-    && mumu_mass > 115
-    && mumu_mass < 135
-
-  H_sideband:   >
-    baseline
-    && (
-         (mumu_mass > 110 && mumu_mass < 115)
-      || (mumu_mass > 135 && mumu_mass < 150)
-       )
-
-  Signal_ext:   >
-    baseline
-    && mumu_mass > 110
-    && mumu_mass < 150
+  baseline: "OS && (mu1_pt > {MuPtTh} && mu2_pt > {MuPtTh})"
+  VBF_def: "HasVBF && j1_pt > 25 && j2_pt > 25"
+  VBF: "baseline && VBF_def"
+  ggH: "baseline && !(VBF_def)"
+  # temporary jet‐veto subcategories
+  VBF_JetVeto_def: "VBF_def && ((abs(j1_eta) < 2.5 || abs(j1_eta) > 3 || j1_pt > 50) && (abs(j2_eta) < 2.5 || abs(j2_eta) > 3 || j2_pt > 50))"
+  VBF_JetVeto: "baseline && VBF_JetVeto_def"
+  ggH_JetVeto: "baseline && !VBF_JetVeto_def"
 
 singleMu_th:
-  "Run2_2016":      26
+  "Run2_2016": 26
   "Run2_2016_HIPM": 26
-  "Run2_2017":      29
-  "Run2_2018":      26
-  "Run3_2022":      26
-  "Run3_2022EE":    26
+  "Run2_2017": 29
+  "Run2_2018": 26
+  "Run3_2022": 26
+  "Run3_2022EE": 26
 
 scales:
   - Up

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -36,10 +36,10 @@ region_default: All
 
 # QCD control regions by dimuon mass
 QCDRegions:
-  Z_sideband: "baseline && mumu_mass > 70 && mumu_mass < 110"
-  Signal_Fit: "baseline && mumu_mass > 115 && mumu_mass < 135"
-  H_sideband: "baseline && ((mumu_mass > 110 && mumu_mass < 115) || (mumu_mass > 135 && mumu_mass < 150))"
-  Signal_ext: "baseline && mumu_mass > 110 && mumu_mass < 150"
+  Z_sideband: "mumu_mass > 70 && mumu_mass < 110"
+  Signal_Fit: "mumu_mass > 115 && mumu_mass < 135"
+  H_sideband: "((mumu_mass > 110 && mumu_mass < 115) || (mumu_mass > 135 && mumu_mass < 150))"
+  Signal_ext: "mumu_mass > 110 && mumu_mass < 150"
 
 ApplyBweight: False
 triggers:

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -62,6 +62,9 @@ category_definition:
   VBF_JetVeto_def: "VBF_def && ((abs(j1_eta) < 2.5 || abs(j1_eta) > 3 || j1_pt > 50) && (abs(j2_eta) < 2.5 || abs(j2_eta) > 3 || j2_pt > 50))"
   VBF_JetVeto: "baseline && VBF_JetVeto_def"
   # ggH_JetVeto: "baseline && !VBF_JetVeto_def"
+  # https://gitlab.cern.ch/cms-jetmet/coordination/coordination/-/issues/113 --> data/MC differences in Jet distributions
+  # spikes are pT dependent, increasing the pT threshold to 50 GeV let them disappear, but reduces significantly the analysis sensitivity
+  # non-physics dependent, but related to Jet Energy Correction and Scale
 
 singleMu_th:
   "Run2_2016": 26

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -34,12 +34,11 @@ corrections:
 region: All
 region_default: All
 
-# QCD control regions by dimuon mass
-QCDRegions:
-  Z_sideband: "mumu_mass > 70 && mumu_mass < 110"
-  Signal_Fit: "mumu_mass > 115 && mumu_mass < 135"
-  H_sideband: "((mumu_mass > 110 && mumu_mass < 115) || (mumu_mass > 135 && mumu_mass < 150))"
-  Signal_ext: "mumu_mass > 110 && mumu_mass < 150"
+QCDregions:
+  Z_sideband: "m_mumu > 70 && m_mumu < 110"
+  Signal_Fit: "m_mumu > 115 && m_mumu < 135"
+  H_sideband: "((m_mumu > 110 && m_mumu < 115) || (m_mumu > 135 && m_mumu < 150))"
+  Signal_ext: "m_mumu > 110 && m_mumu < 150"
 
 ApplyBweight: False
 triggers:
@@ -56,12 +55,10 @@ categories:
   - ggH_JetVeto
 
 category_definition:
-  # main categories
   baseline: "OS && (mu1_pt > {MuPtTh} && mu2_pt > {MuPtTh})"
   VBF_def: "HasVBF && j1_pt > 25 && j2_pt > 25"
   VBF: "baseline && VBF_def"
   ggH: "baseline && !(VBF_def)"
-  # temporary jet‐veto subcategories
   VBF_JetVeto_def: "VBF_def && ((abs(j1_eta) < 2.5 || abs(j1_eta) > 3 || j1_pt > 50) && (abs(j2_eta) < 2.5 || abs(j2_eta) > 3 || j2_pt > 50))"
   VBF_JetVeto: "baseline && VBF_JetVeto_def"
   ggH_JetVeto: "baseline && !VBF_JetVeto_def"

--- a/config/law.cfg
+++ b/config/law.cfg
@@ -1,7 +1,6 @@
 [modules]
 FLAF.AnaProd.tasks
 FLAF.Analysis.tasks
-AnaProd.tasks
 #FLAF.RunKit.grid_helper_tasks
 #FLAF.RunKit.crabLaw
 # inference.dhi.tasks


### PR DESCRIPTION
1. We introduced the jet‐veto subcategories not because the core physics changed, but to work around a known data/MC mismatch in a narrow η–pₜ window of our forward jets. In the region 2.5 < |η| < 3.0 at moderate pₜ (30–50 GeV), the simulation showed unphysical spikes or horns that didn’t appear in data (https://gitlab.cern.ch/cms-jetmet/coordination/coordination/-/issues/113), driven by imperfect jet energy corrections and resolution(and under further investigation). Those mismodeled jets can skew our background shapes or pull the fit in the VBF and ggH categories, compromising sensitivity. We define a veto requiring each leading jet to be either truly central (|η|<2.5), very forward (|η|>3), or above 50 GeV. Subcategories added are: VBF_JetVeto  (VBF events that pass this extra clean-jet requirement) and ggH_JetVeto (baseline events that fail the VBF_JetVeto_def). This is a temporary fix in the current pull request. 
2. We split the dimuon mass range into four simple slices (calling them QCDregions for now) so we can check backgrounds and keep the Higgs fit clean, we keep the same naming convention used in the previous analysis. Together, these regions give us control over backgrounds and lets us extract the Higgs signal without mixing in data where we are fitting.