### PR TITLE
Add safety on compute_rel_weights

### DIFF
--- a/Analysis/DNN_Application.py
+++ b/Analysis/DNN_Application.py
@@ -94,20 +94,20 @@ class DNNProducer:
         return parity, input_features
 
     ### Functions for running the inference ###
-    """
+
     def prepare_dfw(self, dfw, dataset_name):
         print("*********** Running prepare_dfw...")
-        corrections = Corrections.getGlobal()
-        dfw = analysis.DataFrameBuilderForHistograms(
-            dfw.df, self.global_cfg, self.period, corrections
-        )
-        print(
-            f"when creating DataFrameBuilderForHistograms, dfw has {dfw.df.Count().GetValue()} entries"
-        )
-        dfw = analysis.PrepareDFBuilder(dfw)
-        print(f"on top of PrepareDFBuilder it has {dfw.df.Count().GetValue()} entries")
+        # Moving AnalysisCache to work on the HistTupleDef DFW
+        # corrections = Corrections.getGlobal()
+        # dfw = analysis.DataFrameBuilderForHistograms(
+        #     dfw.df, self.global_cfg, self.period, corrections
+        # )
+        # print(
+        #     f"when creating DataFrameBuilderForHistograms, dfw has {dfw.df.Count().GetValue()} entries"
+        # )
+        # dfw = analysis.PrepareDFBuilder(dfw)
+        # print(f"on top of PrepareDFBuilder it has {dfw.df.Count().GetValue()} entries")
         return dfw
-    """
 
     def ApplyDNN(self, branches):
         print("*********** Running ApplyDNN...")

--- a/Analysis/DNN_Application.py
+++ b/Analysis/DNN_Application.py
@@ -94,7 +94,7 @@ class DNNProducer:
         return parity, input_features
 
     ### Functions for running the inference ###
-
+    """
     def prepare_dfw(self, dfw, dataset_name):
         print("*********** Running prepare_dfw...")
         corrections = Corrections.getGlobal()
@@ -107,6 +107,7 @@ class DNNProducer:
         dfw = analysis.PrepareDFBuilder(dfw)
         print(f"on top of PrepareDFBuilder it has {dfw.df.Count().GetValue()} entries")
         return dfw
+    """
 
     def ApplyDNN(self, branches):
         print("*********** Running ApplyDNN...")

--- a/Analysis/PostVBFNetDNN_Application.py
+++ b/Analysis/PostVBFNetDNN_Application.py
@@ -96,11 +96,12 @@ class PostVBFNetDNNProducer:
 
     def prepare_dfw(self, dfw, dataset_name):
         print("*********** Running prepare_dfw...")
-        corrections = Corrections.getGlobal()
-        dfw = analysis.DataFrameBuilderForHistograms(
-            dfw.df, self.global_cfg, self.period, corrections
-        )
-        dfw = analysis.PrepareDFBuilder(dfw)
+        # Moving AnalysisCache to work on the HistTupleDef DFW
+        # corrections = Corrections.getGlobal()
+        # dfw = analysis.DataFrameBuilderForHistograms(
+        #     dfw.df, self.global_cfg, self.period, corrections
+        # )
+        # dfw = analysis.PrepareDFBuilder(dfw)
         dfw.df = VBFNetJetCollectionDef(dfw.df)
         return dfw
 

--- a/Analysis/VBFNet_Application.py
+++ b/Analysis/VBFNet_Application.py
@@ -92,11 +92,12 @@ class VBFNetProducer:
 
     def prepare_dfw(self, dfw, dataset_name):
         print("*********** Running prepare_dfw...")
-        corrections = Corrections.getGlobal()
-        dfw = analysis.DataFrameBuilderForHistograms(
-            dfw.df, self.global_cfg, self.period, corrections
-        )
-        dfw = analysis.PrepareDFBuilder(dfw)
+        # Moving AnalysisCache to work on the HistTupleDef DFW
+        # corrections = Corrections.getGlobal()
+        # dfw = analysis.DataFrameBuilderForHistograms(
+        #     dfw.df, self.global_cfg, self.period, corrections
+        # )
+        # dfw = analysis.PrepareDFBuilder(dfw)
         dfw.df = VBFNetJetCollectionDef(dfw.df)
         return dfw
 

--- a/Analysis/histTupleDef.py
+++ b/Analysis/histTupleDef.py
@@ -40,7 +40,7 @@ def GetDfw(df, setup, dataset_name):
     )  # here go the customisations for each analysis eventually extrcting stuff from the global params
     kwargset["isData"] = global_params["process_group"] == "data"
     kwargset["wantTriggerSFErrors"] = (
-        global_params["compute_rel_weights"]
+        global_params.get("compute_rel_weights", False)
         and "trigger" in corrections.to_apply.keys()
     )
     print(kwargset["wantTriggerSFErrors"])


### PR DESCRIPTION
Moving FLAF to use histTupleDef on the AnalysisCache DFW creation -- but currently hmumu analysis has a hard requirement for ```compute_rel_weights``` in the histTupleDef which does not exist unless called with a command line arg. Put a get with default false.