### PR TITLE
Redesign documentation (cms-flaf/FLAF#113)

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,0 +1,48 @@
+name: Deploy documentation
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/deploy-docs.yaml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/deploy-docs.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install MkDocs Material
+        run: pip install mkdocs-material
+      - name: Build site (strict)
+        run: mkdocs build --strict
+
+  deploy:
+    needs: validate
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-docs
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install MkDocs Material
+        run: pip install mkdocs-material
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/docs/analysis.md
+++ b/docs/analysis.md
@@ -1,0 +1,48 @@
+# Running the analysis
+
+The pipeline — anaTuples, observables, histograms, plots — is the **standard FLAF chain**; follow
+the **[FLAF full-workflow walkthrough](https://cms-flaf.github.io/FLAF/workflow/walkthrough/)** for
+the commands (`InputFileTask` → … → `HistPlotTask`). This page collects what is **specific to
+H→μμ**.
+
+```sh
+ERA=Run3_2022
+VER=dev
+
+law run FLAF.Analysis.tasks.HistPlotTask \
+  --period $ERA --version $VER --workflow local --branches 0 --test 1000
+```
+
+## No statistical-inference stage here
+
+Unlike the HH analyses, H→μμ does **not** include a statistical-inference step in this repository —
+there is no `StatInference`/`inference` submodule, and the pipeline ends at histograms/plots. Any
+interpretation is done with separate tooling outside this repository.
+
+## Categories
+
+H→μμ is split into production-mode categories (e.g. VBF- and ggH-enriched selections). Category and
+channel selection is driven by `config/global.yaml`; adjust it there or via your
+[`user_custom.yaml`](https://cms-flaf.github.io/FLAF/configuration/user-custom/).
+
+## Running all eras
+
+H→μμ targets every Run 3 era. Run a stage per era, or — in CI — set `H_mumu_eras: ALL` (see
+[FLAF → Integration pipeline](https://cms-flaf.github.io/FLAF/ci/integration-pipeline/)). Remember
+that one `law run` processes **one** `--period` at a time.
+
+## Choosing which variables to histogram
+
+As for any FLAF analysis, the variable set is controlled by the `variables:` list in
+`user_custom.yaml` (or `--variables`):
+
+```yaml
+variables:
+  - mu1_pt
+  - m_mumu
+```
+
+!!! note "Lower-case CI process names"
+    H→μμ's CI process names are lower-case (`custom_CI_signal`, `custom_CI_background`,
+    `custom_CI_data`) — unlike the capitalised names in the HH analyses. Use the exact name from
+    `config/processes.yaml` when passing `--process`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,53 @@
+# H → μμ
+
+This is the documentation for the **H→μμ** analysis — the search for the Higgs boson decaying to a
+muon pair, built on the [FLAF framework](https://cms-flaf.github.io/FLAF/). It is a **single-Higgs**
+analysis with the **leanest** FLAF setup.
+
+!!! abstract "The common workflow lives in the FLAF docs"
+    H→μμ runs on FLAF, so installation, the task pipeline (NanoAOD → anaTuples → histograms →
+    plots), the configuration system, storage, eras and CI are **shared with every FLAF analysis**
+    and documented once, in the **[FLAF documentation](https://cms-flaf.github.io/FLAF/)**:
+
+    - [Prerequisites & installation](https://cms-flaf.github.io/FLAF/getting-started/installation/)
+    - [Your first run](https://cms-flaf.github.io/FLAF/getting-started/first-run/)
+    - [Full workflow walkthrough](https://cms-flaf.github.io/FLAF/workflow/walkthrough/)
+    - [Command arguments](https://cms-flaf.github.io/FLAF/workflow/arguments/)
+
+    **This site covers only what is specific to H→μμ.**
+
+## How H→μμ differs from the HH analyses
+
+| Aspect | H→μμ |
+|---|---|
+| Process | **Single** Higgs (H→μμ), not di-Higgs. |
+| Submodules | The simplest set: just **`FLAF`** and **`Corrections`**. |
+| Statistical inference | **None** in this repository — there is no `StatInference`/`inference` submodule. |
+| Eras | Runs over **all** Run 3 eras (CI uses `ALL`). |
+| CI process names | **lower-case** (`custom_CI_signal`, `custom_CI_background`, `custom_CI_data`). |
+
+## Quickstart
+
+```sh
+git clone --recursive git@github.com:cms-flaf/H_mumu.git
+cd H_mumu
+source env.sh                                  # first time builds the environment
+voms-proxy-init -voms cms -rfc -valid 192:00
+law index --verbose
+```
+
+Then smoke-test the chain (see
+[FLAF → first run](https://cms-flaf.github.io/FLAF/getting-started/first-run/)):
+
+```sh
+law run FLAF.Analysis.tasks.HistPlotTask \
+  --version my_first_run --period Run3_2022 --workflow local --branches 0 --test 1000
+```
+
+New to FLAF? Read [Key terms](https://cms-flaf.github.io/FLAF/getting-started/key-terms/) and
+[Concepts](https://cms-flaf.github.io/FLAF/concepts/architecture/) first.
+
+## Eras
+
+H→μμ runs over all Run 3 eras (`Run3_2022`, `Run3_2022EE`, `Run3_2023`, `Run3_2023BPix`, and newer
+as they come online). See [FLAF → Eras](https://cms-flaf.github.io/FLAF/concepts/eras/).

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,44 @@
+# Setup
+
+H→μμ is installed and run like any FLAF analysis, and it has the **simplest** setup of the three —
+only the shared `FLAF` and `Corrections` submodules. The general procedure (prerequisites, what the
+first `source env.sh` builds) is in the
+**[FLAF installation guide](https://cms-flaf.github.io/FLAF/getting-started/installation/)**.
+
+## Clone
+
+```sh
+git clone --recursive git@github.com:cms-flaf/H_mumu.git
+cd H_mumu
+source env.sh
+```
+
+`--recursive` pulls `FLAF` and `Corrections`; without it, imports fail on empty directories.
+
+!!! tip "Working from a fork"
+    For contributions it is convenient to
+    [fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo)
+    `cms-flaf/H_mumu` and add your fork as a remote. See
+    [FLAF → Contributing](https://cms-flaf.github.io/FLAF/contributing/).
+
+## Submodules
+
+| Submodule | Role |
+|---|---|
+| `FLAF` | The shared framework. |
+| `Corrections` | Object corrections & systematics. |
+
+There are **no** analysis-specific physics submodules and **no** statistical-inference submodule —
+this is what makes H→μμ the lightest analysis to set up.
+
+## Production model
+
+The production [physics model](https://cms-flaf.github.io/FLAF/configuration/processes-and-models/)
+is `BaseModel` (set in `config/global.yaml`). For fast local tests, set `phys_model: TestModel` in
+your [`user_custom.yaml`](https://cms-flaf.github.io/FLAF/configuration/user-custom/).
+
+## Next
+
+- [Running the analysis](analysis.md) — the H→μμ-specific run notes.
+- [FLAF → Full workflow](https://cms-flaf.github.io/FLAF/workflow/walkthrough/) — the common
+  pipeline, stage by stage.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,7 +67,6 @@ plugins:
 
 extra_javascript:
   - https://unpkg.com/mermaid@9.3/dist/mermaid.min.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 nav:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,76 @@
+site_name: H->mumu
+site_description: >-
+  H -> mu mu analysis built on the FLAF framework. Analysis-specific setup and run notes.
+  The common pipeline is documented in the FLAF docs.
+repo_name: cms-flaf/H_mumu
+repo_url: https://github.com/cms-flaf/H_mumu
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  font: false
+  logo: https://cms.cern/sites/default/files/logo/cms_logo_neg03_2.png
+  features:
+    - content.action.edit
+    - content.action.view
+    - content.code.copy
+    - navigation.footer
+    - navigation.indexes
+    - navigation.sections
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.top
+    - navigation.tracking
+    - search.highlight
+    - search.share
+    - search.suggest
+    - toc.follow
+
+markdown_extensions:
+  - attr_list
+  - admonition
+  - def_list
+  - footnotes
+  - meta
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.arithmatex:
+      generic: true
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.caret
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde
+
+plugins:
+  - search
+
+extra_javascript:
+  - https://unpkg.com/mermaid@9.3/dist/mermaid.min.js
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+
+nav:
+  - Home: index.md
+  - Setup: setup.md
+  - Running the analysis: analysis.md


### PR DESCRIPTION
Part of the FLAF documentation redesign — see cms-flaf/FLAF#113.

The common workflow is documented once in the FLAF docs; this repo gets a focused supplement covering only what is specific to **H_mumu**, linking back to the FLAF site for everything shared.

Adds/rewrites `docs/` + `mkdocs.yml` and a GitHub Pages **deploy workflow** (`.github/workflows/deploy-docs.yaml`).

**Testing:** `mkdocs build --strict` passes with no warnings; `mkdocs.yml` passes `yamllint`.