### PR TITLE
Enable W stitching and single DY bkg with flavor+m_ll (#169)

### DIFF
--- a/config/Run3_2022/processes.yaml
+++ b/config/Run3_2022/processes.yaml
@@ -52,7 +52,7 @@ DYto2L_PtBinned:
     - DYto2L_M_50_PTLL_600_2J_amcatnloFXFX
 
 DYto2L_InclusivePlusBinned:
-  processors: *DY_processors_allFlavors
+  processors: *DY_flavor_mll_processors
   corrections:
     Vpt:
       type: DY
@@ -72,6 +72,7 @@ DYto2L_InclusivePlusBinned:
     - DYto2L_M_50_PTLL_200to400_2J_amcatnloFXFX
     - DYto2L_M_50_PTLL_400to600_2J_amcatnloFXFX
     - DYto2L_M_50_PTLL_600_2J_amcatnloFXFX
+    - DYto2Mu_MLL_105to160_amcatnloFXFX
 
 
 DY_M_10to50:
@@ -109,7 +110,7 @@ DYto2E_M_50:
     - DYto2E_M_50_PTLL_600_2J_amcatnloFXFX
 
 DYto2Mu_M_50:
-  processors: *DY_mll_processors
+  processors: *DY_processors_singleFlavor
   corrections:
     Vpt:
       type: DY
@@ -129,7 +130,6 @@ DYto2Mu_M_50:
     - DYto2Mu_M_50_PTLL_200to400_2J_amcatnloFXFX
     - DYto2Mu_M_50_PTLL_400to600_2J_amcatnloFXFX
     - DYto2Mu_M_50_PTLL_600_2J_amcatnloFXFX
-    - DYto2Mu_MLL_105to160_amcatnloFXFX
 
 DYto2Tau_M_50:
   processors: *DY_processors_singleFlavor

--- a/config/Run3_2022/processes.yaml
+++ b/config/Run3_2022/processes.yaml
@@ -109,7 +109,7 @@ DYto2E_M_50:
     - DYto2E_M_50_PTLL_600_2J_amcatnloFXFX
 
 DYto2Mu_M_50:
-  processors: *DY_processors_singleFlavor
+  processors: *DY_mll_processors
   corrections:
     Vpt:
       type: DY
@@ -129,6 +129,7 @@ DYto2Mu_M_50:
     - DYto2Mu_M_50_PTLL_200to400_2J_amcatnloFXFX
     - DYto2Mu_M_50_PTLL_400to600_2J_amcatnloFXFX
     - DYto2Mu_M_50_PTLL_600_2J_amcatnloFXFX
+    - DYto2Mu_MLL_105to160_amcatnloFXFX
 
 DYto2Tau_M_50:
   processors: *DY_processors_singleFlavor

--- a/config/Run3_2022/processes.yaml
+++ b/config/Run3_2022/processes.yaml
@@ -201,10 +201,21 @@ W_NJets:
   name: "W $\\rightarrow \\ell \\nu$+ jets"
   color: "kGreen"  # eliminates need for plot.yaml
   color_mplhep: yellow
+  processors: *W_processors
   datasets:
     - WtoLNu_0J_amcatnloFXFX
     - WtoLNu_1J_amcatnloFXFX
     - WtoLNu_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_40to100_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_100to200_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_200to400_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_400to600_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_600_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_40to100_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_100to200_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_200to400_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_400to600_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_600_2J_amcatnloFXFX
 
 ############## EWK ##############
 EWK_LLJJ:

--- a/config/Run3_2022EE/processes.yaml
+++ b/config/Run3_2022EE/processes.yaml
@@ -102,7 +102,7 @@ DYto2E_M_50:
     - DYto2E_M_50_PTLL_600_2J_amcatnloFXFX
 
 DYto2Mu_M_50:
-  processors: *DY_processors_singleFlavor
+  processors: *DY_mll_processors
   corrections:
     Vpt:
       type: DY
@@ -122,6 +122,7 @@ DYto2Mu_M_50:
     - DYto2Mu_M_50_PTLL_200to400_2J_amcatnloFXFX
     - DYto2Mu_M_50_PTLL_400to600_2J_amcatnloFXFX
     - DYto2Mu_M_50_PTLL_600_2J_amcatnloFXFX
+    - DYto2Mu_MLL_105to160_amcatnloFXFX
 
 DYto2Tau_M_50:
   processors: *DY_processors_singleFlavor

--- a/config/Run3_2022EE/processes.yaml
+++ b/config/Run3_2022EE/processes.yaml
@@ -45,7 +45,7 @@ DYto2L_PtBinned:
     - DYto2L_M_50_PTLL_600_2J_amcatnloFXFX
 
 DYto2L_InclusivePlusBinned:
-  processors: *DY_processors_allFlavors
+  processors: *DY_flavor_mll_processors
   corrections:
     Vpt:
       type: DY
@@ -65,6 +65,7 @@ DYto2L_InclusivePlusBinned:
     - DYto2L_M_50_PTLL_200to400_2J_amcatnloFXFX
     - DYto2L_M_50_PTLL_400to600_2J_amcatnloFXFX
     - DYto2L_M_50_PTLL_600_2J_amcatnloFXFX
+    - DYto2Mu_MLL_105to160_amcatnloFXFX
 
 
 DY_M_10to50:
@@ -102,7 +103,7 @@ DYto2E_M_50:
     - DYto2E_M_50_PTLL_600_2J_amcatnloFXFX
 
 DYto2Mu_M_50:
-  processors: *DY_mll_processors
+  processors: *DY_processors_singleFlavor
   corrections:
     Vpt:
       type: DY
@@ -122,7 +123,6 @@ DYto2Mu_M_50:
     - DYto2Mu_M_50_PTLL_200to400_2J_amcatnloFXFX
     - DYto2Mu_M_50_PTLL_400to600_2J_amcatnloFXFX
     - DYto2Mu_M_50_PTLL_600_2J_amcatnloFXFX
-    - DYto2Mu_MLL_105to160_amcatnloFXFX
 
 DYto2Tau_M_50:
   processors: *DY_processors_singleFlavor

--- a/config/Run3_2022EE/processes.yaml
+++ b/config/Run3_2022EE/processes.yaml
@@ -175,10 +175,21 @@ W_NJets:
   name: "W $\\rightarrow \\ell \\nu$+ jets"
   color: "kGreen"  # eliminates need for plot.yaml
   color_mplhep: yellow
+  processors: *W_processors
   datasets:
     - WtoLNu_0J_amcatnloFXFX
     - WtoLNu_1J_amcatnloFXFX
     - WtoLNu_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_40to100_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_100to200_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_200to400_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_400to600_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_600_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_40to100_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_100to200_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_200to400_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_400to600_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_600_2J_amcatnloFXFX
 
 ############## EWK ##############
 EWK_LLJJ:

--- a/config/Run3_2023/processes.yaml
+++ b/config/Run3_2023/processes.yaml
@@ -41,7 +41,7 @@ DYto2L_PtBinned:
     - DYto2L_M_50_PTLL_600_2J_amcatnloFXFX
 
 DYto2L_InclusivePlusBinned:
-  processors: *DY_processors_allFlavors
+  processors: *DY_flavor_mll_processors
   corrections:
     Vpt:
       type: DY
@@ -61,6 +61,7 @@ DYto2L_InclusivePlusBinned:
     - DYto2L_M_50_PTLL_200to400_2J_amcatnloFXFX
     - DYto2L_M_50_PTLL_400to600_2J_amcatnloFXFX
     - DYto2L_M_50_PTLL_600_2J_amcatnloFXFX
+    - DYto2Mu_MLL_105to160_amcatnloFXFX
 
 
 DY_M_10to50:
@@ -98,7 +99,7 @@ DYto2E_M_50:
     - DYto2E_M_50_PTLL_600_2J_amcatnloFXFX
 
 DYto2Mu_M_50:
-  processors: *DY_mll_processors
+  processors: *DY_processors_singleFlavor
   corrections:
     Vpt:
       type: DY
@@ -118,7 +119,6 @@ DYto2Mu_M_50:
     - DYto2Mu_M_50_PTLL_200to400_2J_amcatnloFXFX
     - DYto2Mu_M_50_PTLL_400to600_2J_amcatnloFXFX
     - DYto2Mu_M_50_PTLL_600_2J_amcatnloFXFX
-    - DYto2Mu_MLL_105to160_amcatnloFXFX
 
 DYto2Tau_M_50:
   processors: *DY_processors_singleFlavor

--- a/config/Run3_2023/processes.yaml
+++ b/config/Run3_2023/processes.yaml
@@ -98,7 +98,7 @@ DYto2E_M_50:
     - DYto2E_M_50_PTLL_600_2J_amcatnloFXFX
 
 DYto2Mu_M_50:
-  processors: *DY_processors_singleFlavor
+  processors: *DY_mll_processors
   corrections:
     Vpt:
       type: DY
@@ -118,6 +118,7 @@ DYto2Mu_M_50:
     - DYto2Mu_M_50_PTLL_200to400_2J_amcatnloFXFX
     - DYto2Mu_M_50_PTLL_400to600_2J_amcatnloFXFX
     - DYto2Mu_M_50_PTLL_600_2J_amcatnloFXFX
+    - DYto2Mu_MLL_105to160_amcatnloFXFX
 
 DYto2Tau_M_50:
   processors: *DY_processors_singleFlavor

--- a/config/Run3_2023/processes.yaml
+++ b/config/Run3_2023/processes.yaml
@@ -172,10 +172,21 @@ W_NJets:
   name: "W $\\rightarrow \\ell \\nu$+ jets"
   color: "kGreen"  # eliminates need for plot.yaml
   color_mplhep: yellow
+  processors: *W_processors
   datasets:
     - WtoLNu_0J_amcatnloFXFX
     - WtoLNu_1J_amcatnloFXFX
     - WtoLNu_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_40to100_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_100to200_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_200to400_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_400to600_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_600_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_40to100_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_100to200_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_200to400_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_400to600_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_600_2J_amcatnloFXFX
 
 ############## EWK ##############
 EWK_LLJJ:

--- a/config/Run3_2023BPix/processes.yaml
+++ b/config/Run3_2023BPix/processes.yaml
@@ -42,7 +42,7 @@ DYto2L_PtBinned:
     - DYto2L_M_50_PTLL_600_2J_amcatnloFXFX
 
 DYto2L_InclusivePlusBinned:
-  processors: *DY_processors_allFlavors
+  processors: *DY_flavor_mll_processors
   corrections:
     Vpt:
       type: DY
@@ -62,6 +62,7 @@ DYto2L_InclusivePlusBinned:
     - DYto2L_M_50_PTLL_200to400_2J_amcatnloFXFX
     - DYto2L_M_50_PTLL_400to600_2J_amcatnloFXFX
     - DYto2L_M_50_PTLL_600_2J_amcatnloFXFX
+    - DYto2Mu_MLL_105to160_amcatnloFXFX
 
 
 DY_M_10to50:
@@ -99,7 +100,7 @@ DYto2E_M_50:
     - DYto2E_M_50_PTLL_600_2J_amcatnloFXFX
 
 DYto2Mu_M_50:
-  processors: *DY_mll_processors
+  processors: *DY_processors_singleFlavor
   corrections:
     Vpt:
       type: DY
@@ -119,7 +120,6 @@ DYto2Mu_M_50:
     - DYto2Mu_M_50_PTLL_200to400_2J_amcatnloFXFX
     - DYto2Mu_M_50_PTLL_400to600_2J_amcatnloFXFX
     - DYto2Mu_M_50_PTLL_600_2J_amcatnloFXFX
-    - DYto2Mu_MLL_105to160_amcatnloFXFX
 
 DYto2Tau_M_50:
   processors: *DY_processors_singleFlavor

--- a/config/Run3_2023BPix/processes.yaml
+++ b/config/Run3_2023BPix/processes.yaml
@@ -99,7 +99,7 @@ DYto2E_M_50:
     - DYto2E_M_50_PTLL_600_2J_amcatnloFXFX
 
 DYto2Mu_M_50:
-  processors: *DY_processors_singleFlavor
+  processors: *DY_mll_processors
   corrections:
     Vpt:
       type: DY
@@ -119,6 +119,7 @@ DYto2Mu_M_50:
     - DYto2Mu_M_50_PTLL_200to400_2J_amcatnloFXFX
     - DYto2Mu_M_50_PTLL_400to600_2J_amcatnloFXFX
     - DYto2Mu_M_50_PTLL_600_2J_amcatnloFXFX
+    - DYto2Mu_MLL_105to160_amcatnloFXFX
 
 DYto2Tau_M_50:
   processors: *DY_processors_singleFlavor

--- a/config/Run3_2023BPix/processes.yaml
+++ b/config/Run3_2023BPix/processes.yaml
@@ -172,10 +172,21 @@ W_NJets:
   name: "W $\\rightarrow \\ell \\nu$+ jets"
   color: "kGreen"  # eliminates need for plot.yaml
   color_mplhep: yellow
+  processors: *W_processors
   datasets:
     - WtoLNu_0J_amcatnloFXFX
     - WtoLNu_1J_amcatnloFXFX
     - WtoLNu_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_40to100_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_100to200_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_200to400_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_400to600_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_600_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_40to100_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_100to200_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_200to400_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_400to600_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_600_2J_amcatnloFXFX
 
 ############## EWK ##############
 EWK_LLJJ:

--- a/config/Run3_2024/processes.yaml
+++ b/config/Run3_2024/processes.yaml
@@ -45,7 +45,7 @@ DYto2E_M_50:
     # - DYto2E_M_50_PTLL_600_2J_amcatnloFXFX
 
 DYto2Mu_M_50:
-  processors: *DY_processors_singleFlavor
+  processors: *DY_mll_processors
   corrections:
     Vpt:
       type: DY
@@ -56,6 +56,7 @@ DYto2Mu_M_50:
     - DYto2Mu_M_50_0J_amcatnloFXFX
     - DYto2Mu_M_50_1J_amcatnloFXFX
     - DYto2Mu_M_50_2J_amcatnloFXFX
+    - DYto2Mu_MLL_105to160_amcatnloFXFX
     # - DYto2Mu_M_50_PTLL_40to100_1J_amcatnloFXFX
     # - DYto2Mu_M_50_PTLL_100to200_1J_amcatnloFXFX
     # - DYto2Mu_M_50_PTLL_200to400_1J_amcatnloFXFX

--- a/config/Run3_2024/processes.yaml
+++ b/config/Run3_2024/processes.yaml
@@ -45,7 +45,7 @@ DYto2E_M_50:
     # - DYto2E_M_50_PTLL_600_2J_amcatnloFXFX
 
 DYto2Mu_M_50:
-  processors: *DY_mll_processors
+  processors: *DY_processors_singleFlavor
   corrections:
     Vpt:
       type: DY
@@ -56,7 +56,6 @@ DYto2Mu_M_50:
     - DYto2Mu_M_50_0J_amcatnloFXFX
     - DYto2Mu_M_50_1J_amcatnloFXFX
     - DYto2Mu_M_50_2J_amcatnloFXFX
-    - DYto2Mu_MLL_105to160_amcatnloFXFX
     # - DYto2Mu_M_50_PTLL_40to100_1J_amcatnloFXFX
     # - DYto2Mu_M_50_PTLL_100to200_1J_amcatnloFXFX
     # - DYto2Mu_M_50_PTLL_200to400_1J_amcatnloFXFX

--- a/config/phys_models.yaml
+++ b/config/phys_models.yaml
@@ -2,7 +2,6 @@ BaseModel:
   name: "Base Model"
   backgrounds:
     - DY
-    - DYto2Mu_MLL105To160
     # - DYto2Mu_MLL105To160_FlashSim # no files available
     - TT
     - VV

--- a/config/processes.yaml
+++ b/config/processes.yaml
@@ -29,6 +29,16 @@
       AnaTuple: file
       AnaTupleMerge: process
 
+.DY_mll_processors: &DY_mll_processors
+  - name: Stitcher
+    module: FLAF.Processors.MCStitchingDYMll
+    class: DYMllStitcher
+    config: FLAF/config/Processors/stitching_DY_amcatnlo_Vpt_NpNLO_mll_Mu.yaml
+    stages: [ AnaTuple, AnaTupleMerge ]
+    dependency_level:
+      AnaTuple: file
+      AnaTupleMerge: process
+
 .ext_processor: &ext_processor
   - name: Stitcher
     verbose: 1

--- a/config/processes.yaml
+++ b/config/processes.yaml
@@ -19,6 +19,16 @@
       AnaTuple: file
       AnaTupleMerge: process
 
+.W_processors: &W_processors
+  - name: Stitcher
+    module: FLAF.Processors.MCStitching
+    class: MCStitcher
+    config: FLAF/config/Processors/stitching_W_amcatnlo_Vpt_NpNLO.yaml
+    stages: [ AnaTuple, AnaTupleMerge ]
+    dependency_level:
+      AnaTuple: file
+      AnaTupleMerge: process
+
 .ext_processor: &ext_processor
   - name: Stitcher
     verbose: 1

--- a/config/processes.yaml
+++ b/config/processes.yaml
@@ -29,11 +29,11 @@
       AnaTuple: file
       AnaTupleMerge: process
 
-.DY_mll_processors: &DY_mll_processors
+.DY_flavor_mll_processors: &DY_flavor_mll_processors
   - name: Stitcher
     module: FLAF.Processors.MCStitchingDYMll
     class: DYMllStitcher
-    config: FLAF/config/Processors/stitching_DY_amcatnlo_Vpt_NpNLO_mll_Mu.yaml
+    config: FLAF/config/Processors/stitching_DY_amcatnlo_Vpt_NpNLO_flavor_mll.yaml
     stages: [ AnaTuple, AnaTupleMerge ]
     dependency_level:
       AnaTuple: file


### PR DESCRIPTION
Wires the new dataset stitchers from cms-flaf/cms-flaf/FLAF#289 (#169) into H_mumu:

- **W+jets**: `W_NJets` gets the W Vpt/NpNLO stitcher + PTLNu bins (amcatnlo eras).
- **DY flavor + m_ll**: a **single DY background** — the all-flavor `DYto2L_InclusivePlusBinned`
  now carries the flavor(e/μ/τ)×m_ll stitcher and the `DYto2Mu_MLL_105to160` sample is stitched
  into the μμ mass window. The separate `DYto2Mu_MLL105To160` background is removed from the model.

`test_setup_loading.py` passes for all eras. **Requires cms-flaf/FLAF#289 + cms-flaf/Corrections#124**.
